### PR TITLE
Added "near" support

### DIFF
--- a/foursquare-server.js
+++ b/foursquare-server.js
@@ -17,7 +17,15 @@ Meteor.methods({
   'foursquare-search': function(config) {
     check(config, Object);
     check(config.query, String);
-    check(config.ll, String);
+    
+    if (!config.ll && !config.near) {
+      var errorMessage = "Foursqaure Error: Please specify either 'll' or 'near' in your params";
+      console.log(errorMessage);
+      throw new Meteor.Error(errorMessage);
+    }
+
+    if (config.ll) check(config.ll, String);
+    if (config.near) check(config.near, String);
 
     if(fs_config.authOnly && !this.userId)
       throw new Meteor.Error('Permission denied');

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'oleh:foursquare',
-  version: '0.0.3',
+  version: '0.0.4',
   // Brief, one-line summary of the package.
   summary: 'Meteor package for searching places with Foursquare API',
   // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
Thank you for creating this package! The Foursquare API allows for either an 'll' property or a 'near' property when searching and I have added support for 'near'.

Here's the relevant API documentation:
https://developer.foursquare.com/docs/venues/search
