### PR TITLE
add missing dependency 'check'

### DIFF
--- a/package.js
+++ b/package.js
@@ -15,6 +15,7 @@ Package.onUse(function(api) {
 
   api.use('underscore');
   api.use('http');
+  api.use('check');
 
   api.addFiles('foursquare-client.js', 'client');
   api.addFiles('foursquare-server.js', 'server');


### PR DESCRIPTION
Hello. Was trying to use your package and got error 'Reference Error:check is not defined'.
[There](http://stackoverflow.com/questions/33521059/check-is-not-defined-in-meteor-js) is a comment about that problem:
`Until the package maintainers update the dependency, you should be able to overcome the error by adding check as a top-level dependency:`
```js
$ meteor add check
```

So I am trying fix that problem in this PR.